### PR TITLE
cleanup

### DIFF
--- a/configs/local/nezha-replica-config-0.yaml
+++ b/configs/local/nezha-replica-config-0.yaml
@@ -9,7 +9,6 @@ replica-id: 0
 receiver-shards: 1 # The number of threads to receive threads
 record-shards: 1 # The number of threads to record requests in the global concurrent map
 track-shards: 1 # The number of threads to record synced log entries
-process-shards: 1 # The number of threads to process requests. For now process-shards is fixed to 1, because the early-buffer enque/deque is hard to parallelize. Maybe later we can find a high-performant **concurrent priority queue** for early-buffer, then process-shards may be parallelized for higher performance
 reply-shards: 2 # The number of threads to send replies (both fast/slow replies)
 index-sync-shards: 1 # The number of threads used by the leader to broadcast index synchronization messages to followers. For followers, they only need one such thread to receive and handle the index sync msgs
 receiver-port: 33333 # The port is exposed to client/proxy and is used to receive client/proxy requests. When receiver-shards>1, the corresponding ports are receiver-ports + shard-index

--- a/configs/local/nezha-replica-config-1.yaml
+++ b/configs/local/nezha-replica-config-1.yaml
@@ -9,7 +9,6 @@ replica-id: 1
 receiver-shards: 1 # The number of threads to receive threads
 record-shards: 1 # The number of threads to record requests in the global concurrent map
 track-shards: 1 # The number of threads to record synced log entries
-process-shards: 1 # The number of threads to process requests. For now process-shards is fixed to 1, because the early-buffer enque/deque is hard to parallelize. Maybe later we can find a high-performant **concurrent priority queue** for early-buffer, then process-shards may be parallelized for higher performance
 reply-shards: 2 # The number of threads to send replies (both fast/slow replies)
 index-sync-shards: 1 # The number of threads used by the leader to broadcast index synchronization messages to followers. For followers, they only need one such thread to receive and handle the index sync msgs
 receiver-port: 33333 # The port is exposed to client/proxy and is used to receive client/proxy requests. When receiver-shards>1, the corresponding ports are receiver-ports + shard-index

--- a/configs/local/nezha-replica-config-2.yaml
+++ b/configs/local/nezha-replica-config-2.yaml
@@ -9,7 +9,6 @@ replica-id: 2
 receiver-shards: 1 # The number of threads to receive threads
 record-shards: 1 # The number of threads to record requests in the global concurrent map
 track-shards: 1 # The number of threads to record synced log entries
-process-shards: 1 # The number of threads to process requests. For now process-shards is fixed to 1, because the early-buffer enque/deque is hard to parallelize. Maybe later we can find a high-performant **concurrent priority queue** for early-buffer, then process-shards may be parallelized for higher performance
 reply-shards: 2 # The number of threads to send replies (both fast/slow replies)
 index-sync-shards: 1 # The number of threads used by the leader to broadcast index synchronization messages to followers. For followers, they only need one such thread to receive and handle the index sync msgs
 receiver-port: 33333 # The port is exposed to client/proxy and is used to receive client/proxy requests. When receiver-shards>1, the corresponding ports are receiver-ports + shard-index

--- a/lib/common_struct.h
+++ b/lib/common_struct.h
@@ -115,9 +115,9 @@ struct RequestBody {
 struct LogEntry {
   // Request Body
   RequestBody body;
-  SHA_HASH myhash;  // The hash value of this **single** entry
-  SHA_HASH hash;  // The accumulative hash, which is calculated based on all the
-                  // log entries from the beginning to this entry
+  SHA_HASH entryHash;  // The hash value of this **single** entry
+  SHA_HASH logHash;  // The accumulative hash, which is calculated based on all
+                     // the log entries from the beginning to this entry
 
   /** prevNonCommutative and nextNonCommutative organize the LogEntries as a
    * skiplist, and easier and more efficient to traverse/modify/delete */
@@ -151,15 +151,15 @@ struct LogEntry {
         result(""),
         status(EntryStatus::INITIAL),
         logId(0) {}
-  LogEntry(const RequestBody& rb, const SHA_HASH& mh, const SHA_HASH& h,
+  LogEntry(const RequestBody& rb, const SHA_HASH& eh, const SHA_HASH& h,
            LogEntry* prevNonComm = NULL, LogEntry* nextNonComm = NULL,
            LogEntry* preNonCOmmW = NULL, LogEntry* nextNonCommW = NULL,
            LogEntry* pre = NULL, LogEntry* nxt = NULL,
            const std::string& re = "", const char sts = EntryStatus::INITIAL,
            const uint32_t lid = 0)
       : body(rb),
-        myhash(mh),
-        hash(h),
+        entryHash(eh),
+        logHash(h),
         prevNonCommutative(prevNonComm),
         nextNonCommutative(nextNonComm),
         prevNonCommutativeWrite(preNonCOmmW),
@@ -171,14 +171,14 @@ struct LogEntry {
         logId(lid) {}
   LogEntry(const uint64_t d, const uint64_t r, const uint32_t ok,
            const uint64_t p, const std::string& cmd, const bool& isw,
-           const SHA_HASH& mh, const SHA_HASH& h, LogEntry* prevNonComm = NULL,
+           const SHA_HASH& eh, const SHA_HASH& h, LogEntry* prevNonComm = NULL,
            LogEntry* nextNonComm = NULL, LogEntry* preNonCOmmW = NULL,
            LogEntry* nextNonCommW = NULL, LogEntry* pre = NULL,
            LogEntry* nxt = NULL, const std::string& re = "",
            const char sts = EntryStatus::INITIAL, const uint32_t lid = 0)
       : body(d, r, ok, p, cmd, isw),
-        myhash(mh),
-        hash(h),
+        entryHash(eh),
+        logHash(h),
         prevNonCommutative(prevNonComm),
         nextNonCommutative(nextNonComm),
         prevNonCommutativeWrite(preNonCOmmW),

--- a/replica/replica_config.h
+++ b/replica/replica_config.h
@@ -11,8 +11,6 @@ struct ReplicaConfig {
   int receiverShards;
   int recordShards;
   int replyShards;
-  int processShards;
-  int indexSyncShards;
   int trackShards;
   int receiverPort;
   int indexSyncPort;
@@ -37,6 +35,14 @@ struct ReplicaConfig {
   int keyNum;
   uint32_t owdEstimationWindow;
   uint32_t reclaimTimeoutMs;
+  int indexSyncShards;
+
+  // The number of threads to process requests. For now process-shards
+  // is fixed to 1, because the early-buffer enque/deque is hard to
+  // parallelize. Maybe later we can find a high-performant **concurrent
+  // priority queue** for early-buffer, then process-shards may be
+  // parallelized for higher performance
+  int processShards = 1;
 
   // Parses yaml file configFilename and fills in fields of ReplicaConfig
   // accordingly. Returns an error message or "" if there are no errors.
@@ -65,8 +71,6 @@ struct ReplicaConfig {
       recordShards = config[key].as<int>();
       key = "reply-shards";
       replyShards = config[key].as<int>();
-      key = "process-shards";
-      processShards = config[key].as<int>();
       key = "index-sync-shards";
       indexSyncShards = config[key].as<int>();
       key = "track-shards";


### PR DESCRIPTION
Several changes for readability:
-  td -> thread
- hash -> logHash
- clarify early buffer logic
- remove processShards from config because it must be 1 and thus should not be configurable.